### PR TITLE
PAT Preserve order of design alternatives througout

### DIFF
--- a/app/app/reports/projectReports/Summary Table.html
+++ b/app/app/reports/projectReports/Summary Table.html
@@ -243,7 +243,8 @@
 
         // Make the comparison point the first run to start
         if ($scope.resultsWithInfo.length > 0) {
-          $scope.baseline = $scope.resultsWithInfo.reverse()[0];
+          // resultsWithInfo is already in the right order
+          $scope.baseline = $scope.resultsWithInfo[0];
           $scope.baseline_name = $scope.baseline.name;
         }
 

--- a/app/app/run/runController.js
+++ b/app/app/run/runController.js
@@ -219,6 +219,21 @@ export class RunController {
         }
       });
       // ensure there is one datapoint per DA
+      // and reorder like the designAlternatives
+      var newDatapoints = [];
+      _.forEach(alternatives, (alt) => {
+        const match = _.find(vm.$scope.datapoints, {name: alt.name});
+        if (!match) {
+          // add empty datapoint to array
+          newDatapoints.push({name: alt.name, id: alt.name, run: false, modified: false});
+        } else {
+          newDatapoints.push(match);
+        }
+      });
+      vm.$scope.datapoints = newDatapoints;
+      // TODO: is it really where it should be reordered?
+      vm.Project.setDatapoints(newDatapoints);
+
       _.forEach(alternatives, (alt) => {
         if (!_.find(vm.$scope.datapoints, {name: alt.name})) {
           // add empty datapoint to array


### PR DESCRIPTION
Try a fix for https://github.com/NREL/OpenStudio/issues/2682

Appears to work without problem on my machine*, but I have a serious doubt that runController.js#L244 is correct...

* If I reorder the design alternatives, the run tab shows the new order, and the Summary Table shows the measure in the same order as well.