### PR TITLE
Algorithmic reports

### DIFF
--- a/app/app/reports/projectReports/EDAPT Export.html
+++ b/app/app/reports/projectReports/EDAPT Export.html
@@ -195,9 +195,11 @@
 
       // Warn user that this report doesn't work in Algorithmic mode
       $scope.setupAfterAlgorithmicResultsAvailable = function () {
+
         if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
           $scope.renderWarns.push("This report will only work with Analysis Type = Manual.");
         }
+        $scope.renderWarns = _.uniq($scope.renderWarns);
       };
 
       // Move the design alternative up one position

--- a/app/app/reports/projectReports/End Use Comparison.html
+++ b/app/app/reports/projectReports/End Use Comparison.html
@@ -56,11 +56,13 @@
     var algorithmic = null;
     var max_plot = 50;
     $scope.setupAfterAlgorithmicResultsAvailable = function () {
+
+      var renderWarns = [];
       if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
         algorithmic = true;
 
-        $scope.renderWarns.push("This report will only work with Analysis Type = Manual.");
-        return
+        renderWarns.push("This report will only work with Analysis Type = Manual.");
+        return;
 
         // this report is only legible up to about 50 datapoints.
         // not with the trouble for user to even setup all the end use output variables
@@ -68,7 +70,7 @@
 
         // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
         if ($scope.algorithm_results.length > max_plot + 1) {
-          $scope.renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+          renderWarns.push("Ony plotting " + max_plot + " algorithmic datapoints out of " + ($scope.algorithm_results.length - 1) + ".");
           $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
         }
 
@@ -91,20 +93,20 @@
             "Water Systems",
             "Refrigeration",
             "Generators"
-          ]
+          ];
           var newData = [];
 
           // Set the energy results properties of each run
           _.forEach($scope.algorithm_results, function (run) {
 
             if (run.name === "") {
-              return
+              return;
             }
 
             // warn and skip of datapoint is missing openstudio_results
             if (!(run.hasOwnProperty('openstudio_results.total_site_eui'))){
-              $scope.renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
-              return
+              renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
+              return;
             }
 
             // Populate an object with the end use data
@@ -126,7 +128,6 @@
 
           });
 
-
           console.log('finish fuel: ', fuel);
 
           // Add this datapoint to the overall set
@@ -143,6 +144,11 @@
 
         console.log('finish both fuels?');
 
+        // Show a unique set of warnings  (dup ng-repeat)
+        _.forEach(_.uniq(renderWarns), (warn) => {
+          if (_.isUndefined(_.find($scope.renderWarns, warn)))
+            $scope.renderWarns.push(warn);
+        });
       }
     };
 
@@ -245,17 +251,13 @@
 
         });
 
-        // Show a unique set of warnings
-        _.forEach(_.uniq(renderWarns), function (warn) {
-          $scope.renderWarns.push(warn);
-
-
+        // Show a unique set of warnings  (no dup ng-repeat)
+        _.forEach(_.uniq(renderWarns), (warn) => {
+          if (_.isUndefined(_.find($scope.renderWarns, warn)))
+            $scope.renderWarns.push(warn);
         });
-
       }
-
     };
-
   });
 
   // Angular directive to create a stacked bar chart

--- a/app/app/reports/projectReports/End Use Comparison.html
+++ b/app/app/reports/projectReports/End Use Comparison.html
@@ -51,112 +51,202 @@
     // Show any issues
     $scope.renderWarns = [];
 
+
+    // gather data for Algorithmic analysis
+    var algorithmic = null;
+    var max_plot = 50;
+    $scope.setupAfterAlgorithmicResultsAvailable = function () {
+      if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
+        algorithmic = true;
+
+        // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
+        if ($scope.algorithm_results.length > max_plot + 1) {
+          $scope.renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+          $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
+        }
+
+        // Populate arrays of data for electricity and gas by end use
+        var fuels = ['end_use_electricity_', 'end_use_natural_gas_'];
+        _.forEach(fuels, function (fuel) {
+
+          var elecEndUseDataColsKeys = [
+            "Heating",
+            "Cooling",
+            "Interior Lighting",
+            "Exterior Lighting",
+            "Interior Equipment",
+            "Exterior Equipment",
+            "Fans",
+            "Pumps",
+            "Heat Rejection",
+            "Humidification",
+            "Heat Recovery",
+            "Water Systems",
+            "Refrigeration",
+            "Generators"
+          ]
+          var newData = [];
+
+          // Set the energy results properties of each run
+          _.forEach($scope.algorithm_results, function (run) {
+
+            if (run.name === "") {
+              return
+            }
+
+            // warn and skip of datapoint is missing openstudio_results
+            if (!(run.hasOwnProperty('openstudio_results.total_site_eui'))){
+              $scope.renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
+              return
+            }
+
+            // Populate an object with the end use data
+            var data = {};
+            data.name = run.name;
+            var tot = 0.0;
+            _.forEach(elecEndUseDataColsKeys, function (key) {
+              // Define the data header
+              var header = key.toLowerCase().replace(' ', '_');
+              var lookup = "openstudio_results." + fuel + header;
+              var val =  parseFloat(run[lookup]);
+              data[header] = val;
+              console.log('What is the problem still: ', run.name + fuel + header + val);
+              tot += val;
+            });
+            data.total = tot;
+
+            newData.push(data);
+
+          });
+
+
+          console.log('finish fuel: ', fuel);
+
+          // Add this datapoint to the overall set
+          //$scope.elecEndUseData.push(data);
+          switch (fuel){
+            case 'end_use_electricity_':
+              $scope.elecEndUseData = newData;
+
+            case 'end_use_natural_gas_':
+              $scope.gasEndUseData = newData;
+          }
+
+        });
+
+        console.log('finish both fuels?');
+
+      }
+    };
+
     // Set up some additional data properties after the results
     // are passed in.
     $scope.setupAfterResultsAvailable = function () {
 
-      var renderWarns = [];
 
-      console.debug('In setupAfterResultsAvailable');
+      if (algorithmic) {
+        return;
+      } else {
 
-      // Populate arrays of data for electricity and gas by end use
-      var fuels = ['end_use_electricity_', 'end_use_natural_gas_'];
-      _.forEach(fuels, function (fuel) {
+        var renderWarns = [];
 
-        var elecEndUseDataColsKeys = [
-          "Heating",
-          "Cooling",
-          "Interior Lighting",
-          "Exterior Lighting",
-          "Interior Equipment",
-          "Exterior Equipment",
-          "Fans",
-          "Pumps",
-          "Heat Rejection",
-          "Humidification",
-          "Heat Recovery",
-          "Water Systems",
-          "Refrigeration",
-          "Generators"
-        ]
-        var newData = [];
-        _.forEach($scope.results, function (run) {
+        console.debug('In setupAfterResultsAvailable');
 
-          // Get the OpenStudio Results measure, which contains the results
-          var reportMeasure = null;
-          _(run.steps).forEach(function (step) {
-            if (step.hasOwnProperty('result')) {
-              if (step.result.measure_uid == "a25386cd-60e4-46bc-8b11-c755f379d916") {
-                reportMeasure = step;
+        // Populate arrays of data for electricity and gas by end use
+        var fuels = ['end_use_electricity_', 'end_use_natural_gas_'];
+        _.forEach(fuels, function (fuel) {
+
+          var elecEndUseDataColsKeys = [
+            "Heating",
+            "Cooling",
+            "Interior Lighting",
+            "Exterior Lighting",
+            "Interior Equipment",
+            "Exterior Equipment",
+            "Fans",
+            "Pumps",
+            "Heat Rejection",
+            "Humidification",
+            "Heat Recovery",
+            "Water Systems",
+            "Refrigeration",
+            "Generators"
+          ]
+          var newData = [];
+          _.forEach($scope.results, function (run) {
+
+            // Get the OpenStudio Results measure, which contains the results
+            var reportMeasure = null;
+            _(run.steps).forEach(function (step) {
+              if (step.hasOwnProperty('result')) {
+                if (step.result.measure_uid == "a25386cd-60e4-46bc-8b11-c755f379d916") {
+                  reportMeasure = step;
+                }
               }
+            });
+            if (!reportMeasure) {
+              renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
+              return;
             }
+
+            // Make sure the results exist
+            if (!reportMeasure.hasOwnProperty('result')){
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
+            }
+
+            // Make sure the results have data
+            var vals = reportMeasure.result.step_values;
+            if (vals.length == 0){
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
+            }
+
+            // Make sure the EUI element exists to ensure measure was run
+            if (!_.find(vals, {'name': "eui"})) {
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
+            }
+
+            // Populate an object with the end use data
+            var data = {};
+            data.name = run.name;
+            var tot = 0.0;
+            _.forEach(elecEndUseDataColsKeys, function (key) {
+              // Define the data header
+              var header = key.toLowerCase().replace(' ', '_');
+              var lookup = fuel + header;
+              var val = _.find(vals, {'name': lookup}).value;
+              data[header] = val;
+              tot += val;
+            });
+            data.total = tot;
+
+            newData.push(data);
+
           });
-          if (!reportMeasure) {
-            renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
-            return;
+
+          // Add this datapoint to the overall set
+          //$scope.elecEndUseData.push(data);
+          switch (fuel){
+            case 'end_use_electricity_':
+              $scope.elecEndUseData = newData;
+
+            case 'end_use_natural_gas_':
+              $scope.gasEndUseData = newData;
           }
-
-          // Make sure the results exist
-          if (!reportMeasure.hasOwnProperty('result')){
-            renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
-            return;
-          }
-
-          // Make sure the results have data
-          var vals = reportMeasure.result.step_values;
-          if (vals.length == 0){
-            renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
-            return;
-          }
-
-          // Make sure the EUI element exists to ensure measure was run
-          if (!_.find(vals, {'name': "eui"})) {
-            renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
-            return;
-          }
-
-          // Populate an object with the end use data
-          var data = {};
-          data.name = run.name;
-          var tot = 0.0;
-          _.forEach(elecEndUseDataColsKeys, function (key) {
-            // Define the data header
-            var header = key.toLowerCase().replace(' ', '_');
-            var lookup = fuel + header;
-            var val = _.find(vals, {'name': lookup}).value;
-            data[header] = val;
-            tot += val;
-          });
-          data.total = tot;
-
-          newData.push(data);
 
         });
 
-        // Add this datapoint to the overall set
-        //$scope.elecEndUseData.push(data);
-        switch (fuel){
-          case 'end_use_electricity_':
-            $scope.elecEndUseData = newData;
+        // Show a unique set of warnings
+        _.forEach(_.uniq(renderWarns), function (warn) {
+          $scope.renderWarns.push(warn);
 
-          case 'end_use_natural_gas_':
-            $scope.gasEndUseData = newData;
-        }
 
-      });
+        });
 
-      // Show a unique set of warnings
-      _.forEach(_.uniq(renderWarns), function (warn) {
-        $scope.renderWarns.push(warn);
-      });
-
-    };
-
-    // Warn user that this report doesn't work in Algorithmic mode
-    $scope.setupAfterAlgorithmicResultsAvailable = function () {
-      if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
-        $scope.renderWarns.push("This report will only work with Analysis Type = Manual.");
       }
+
     };
 
   });
@@ -343,11 +433,12 @@
   }
 
   function setAlgorithmicData(metadata, results) {
+    console.log('Setting algorithmic results variable to: ', results);
     var controllerElement = document.querySelector('div[ng-controller="MyAppCtrl"]');
     var $scope = angular.element(controllerElement).scope();
     $scope.$apply(function () {
-      $scope.algorithm_results = metadata;
-      $scope.algorithm_metadata = results;
+      $scope.algorithm_results = results;
+      $scope.algorithm_metadata = metadata;
       $scope.setupAfterAlgorithmicResultsAvailable();
     });
   }

--- a/app/app/reports/projectReports/End Use Comparison.html
+++ b/app/app/reports/projectReports/End Use Comparison.html
@@ -59,6 +59,13 @@
       if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
         algorithmic = true;
 
+        $scope.renderWarns.push("This report will only work with Analysis Type = Manual.");
+        return
+
+        // this report is only legible up to about 50 datapoints.
+        // not with the trouble for user to even setup all the end use output variables
+        // I have disabled it for algorithmic for now but if warning and return above are removed it will still run
+
         // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
         if ($scope.algorithm_results.length > max_plot + 1) {
           $scope.renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");

--- a/app/app/reports/projectReports/Summary Table No Baseline.html
+++ b/app/app/reports/projectReports/Summary Table No Baseline.html
@@ -66,14 +66,16 @@
 
       // gather data for Algorithmic analysis
       var algorithmic = null;
-      var max_plot = 500;
+      var max_plot = 300;
       $scope.setupAfterAlgorithmicResultsAvailable = function () {
         if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
           algorithmic = true;
 
+          var renderWarns = [];
+
           // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
           if ($scope.algorithm_results.length > max_plot + 1) {
-            $scope.renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+            renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
             $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
           }
 
@@ -86,43 +88,83 @@
 
             // warn and skip of datapoint is missing openstudio_results
             if (!(run.hasOwnProperty('openstudio_results.total_site_eui'))){
-              $scope.renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
+              renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
               return
             }
 
             // EUI
-            //run.eui = 5;
-            run.eui = run["openstudio_results.total_site_eui"];
+            if (!run.hasOwnProperty('openstudio_results.total_site_eui')){
+              renderWarns.push("Enable total_site_eui output variable in OpenStudio Results to populate Energy Use Intensity Column.");
+            } else {
+              run.eui = run["openstudio_results.total_site_eui"];
+            }
 
             // Peak Electric Demand
-            run.peak_electric_demand_ip = run["openstudio_results.annual_peak_electric_demand"];
+            if (!run.hasOwnProperty('openstudio_results.annual_peak_electric_demand')){
+              renderWarns.push("Enable annual_peak_electric_demand output variable in OpenStudio Results to populate Peak Electricity Column.");
+            } else {
+              run.peak_electric_demand_ip = run["openstudio_results.annual_peak_electric_demand"];
+            }
 
             // Electricity Consumption
-            run.electricity_ip = run["openstudio_results.electricity_ip"];
+            if (!run.hasOwnProperty('openstudio_results.electricity_ip')){
+              renderWarns.push("Enable electricity_ip output variable in OpenStudio Results to populate Electricity Consumption Column.");
+            } else {
+              run.electricity_ip = run["openstudio_results.electricity_ip"];
+            }
 
             // Natural Gas Consumption
-            run.natural_gas_ip = run["openstudio_results.natural_gas_ip"];
+            if (!run.hasOwnProperty('openstudio_results.natural_gas_ip')){
+              renderWarns.push("Enable natural_gas_ip output variable in OpenStudio Results to populate Natural Gas Column.");
+            } else {
+              run.natural_gas_ip = run["openstudio_results.natural_gas_ip"];
+            }
 
             //District Cooling Consumption
-            run.district_cooling_cooling_ip = run["openstudio_results.district_cooling_cooling_ip"];
+            if (!run.hasOwnProperty('openstudio_results.district_cooling_cooling_ip')){
+              renderWarns.push("Enable district_cooling_cooling_ip output variable in OpenStudio Results to populate District Cooling Column.");
+            } else {
+              run.district_cooling_cooling_ip = run["openstudio_results.district_cooling_cooling_ip"];
+            }
 
             // District Heating Consumption
-            run.district_heating_ip = run["openstudio_results.district_heating_ip"];
+            if (!run.hasOwnProperty('openstudio_results.district_heating_ip')){
+              renderWarns.push("Enable district_heating_ip output variable in OpenStudio Results to populate District Heating Column.");
+            } else {
+              run.district_heating_ip = run["openstudio_results.district_heating_ip"];
+            }
 
             // First Year Capital Cost
-            run.first_year_cap_cost = run["openstudio_results.first_year_capital_cost"];
+            if (!run.hasOwnProperty('openstudio_results.first_year_capital_cost')){
+              renderWarns.push("Enable first_year_capital_cost output variable in OpenStudio Results to populate First Year Capital Cost Column.");
+            } else {
+              run.first_year_cap_cost = run["openstudio_results.first_year_capital_cost"];
+            }
 
             // Annual Utility Cost
-            run.ann_util_cost = run["openstudio_results.annual_utility_cost"];
+            if (!run.hasOwnProperty('openstudio_results.annual_utility_cost')){
+              renderWarns.push("Enable annual_utility_cost output variable in OpenStudio Results to populate Annual Utility Cost Column.");
+            } else {
+              run.ann_util_cost = run["openstudio_results.annual_utility_cost"];
+            }
 
             // Total LCC
             run.total_lcc = run["openstudio_results.total_lifecycle_cost"];
+
+            if (!run.hasOwnProperty('openstudio_results.total_lifecycle_cost')){
+              renderWarns.push("Enable total_lifecycle_cost output variable in OpenStudio Results to populate Total Lifecycle Cost Column.");
+            } else {
+              run.total_lcc = run["openstudio_results.total_lifecycle_cost"];
+            }
 
             console.log(run.name);
             console.log(run);
             $scope.resultsWithInfo.push(run);
 
           });
+
+          // Show a unique set of warnings
+          $scope.renderWarns = _.uniq(renderWarns);
 
         }
       };

--- a/app/app/reports/projectReports/Summary Table No Baseline.html
+++ b/app/app/reports/projectReports/Summary Table No Baseline.html
@@ -66,7 +66,7 @@
 
       // gather data for Algorithmic analysis
       var algorithmic = null;
-      var max_plot = 300;
+      var max_plot = 1000;
       $scope.setupAfterAlgorithmicResultsAvailable = function () {
         if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
           algorithmic = true;

--- a/app/app/reports/projectReports/Summary Table No Baseline.html
+++ b/app/app/reports/projectReports/Summary Table No Baseline.html
@@ -64,7 +64,7 @@
       // Show any issues
       $scope.renderWarns = [];
 
-      // Warn user that this report doesn't work in Algorithmic mode
+      // gather data for Algorithmic analysis
       var algorithmic = null;
       var max_plot = 500
       $scope.setupAfterAlgorithmicResultsAvailable = function () {

--- a/app/app/reports/projectReports/Summary Table No Baseline.html
+++ b/app/app/reports/projectReports/Summary Table No Baseline.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Summary Table No Baseline</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.2/lodash.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular.min.js"></script>
+</head>
+<body>
+
+<div ng-app="myApp">
+
+  <div ng-controller="MyAppCtrl">
+
+    <h1>Summary Table No Baseline</h1>
+    <ul>
+      <li class="alert alert-warning" ng-repeat="warn in renderWarns">{{ warn }}</li>
+    </ul>
+    <table class="table-bordered table-condensed">
+      <tr>
+        <th>Name</th>
+        <th>Energy Use Intensity <br> (kBtu/ft2-yr)</th>
+        <th>Peak Electric Demand <br> (kW)</th>
+        <th>Electricity <br> (kWh)</th>
+        <th>Natural Gas <br> (Million Btu)</th>
+        <th>District Cooling <br> (Million Btu)</th>
+        <th>District Heating <br> (Million Btu)</th>
+        <th>First Year Capital Cost <br> ($)</th>
+        <th>Annual Utility Cost <br> ($)</th>
+        <th>Total LCC <br> ($)</th>
+      </tr>
+      <tr ng-repeat="run in resultsWithInfo">
+        <td>{{ run.name }}</td>
+        <td>{{ run.eui | number:1}}</td>
+        <td>{{ run.peak_electric_demand_ip | number:1}}</td>
+        <td>{{ run.electricity_ip | number:1}}</td>
+        <td>{{ run.natural_gas_ip | number:1}}</td>
+        <td>{{ run.district_cooling_cooling_ip | number:1}}</td>
+        <td>{{ run.district_heating_ip | number:1}}</td>
+        <td>{{ run.first_year_cap_cost | number:1}}</td>
+        <td>{{ run.ann_util_cost | number:1}}</td>
+        <td>{{ run.total_lcc | number:1}}</td>
+      </tr>
+    </table>
+  </div>
+
+</div>
+
+<script type="text/javascript">
+
+  console.info("Loaded Summary Table.html script");
+
+  angular.module('myApp', [])
+    .controller('MyAppCtrl', function ($scope) {
+
+
+      // Subset of runs with results to show
+      $scope.resultsWithInfo = [];
+
+      // Show any issues
+      $scope.renderWarns = [];
+
+      // Warn user that this report doesn't work in Algorithmic mode
+      var algorithmic = null;
+      var max_plot = 500
+      $scope.setupAfterAlgorithmicResultsAvailable = function () {
+        if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
+          algorithmic = true;
+
+          // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
+          if ($scope.algorithm_results.length > max_plot + 1) {
+            $scope.renderWarns.push("Ony ploting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+            $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
+          }
+
+          // Set the energy results properties of each run
+          _.forEach($scope.algorithm_results, function (run) {
+
+            if (run.name === "") {
+              return
+            }
+
+            // warn and skip of datapoint is missing openstudio_results
+            if (!(run.hasOwnProperty('openstudio_results.total_site_eui'))){
+              $scope.renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
+              return
+            }
+
+            // EUI
+            //run.eui = 5;
+            run.eui = run["openstudio_results.total_site_eui"];
+
+            // Peak Electric Demand
+            run.peak_electric_demand_ip = run["openstudio_results.annual_peak_electric_demand"];
+
+            // Electricity Consumption
+            run.electricity_ip = run["openstudio_results.electricity_ip"];
+
+            // Natural Gas Consumption
+            run.natural_gas_ip = run["openstudio_results.natural_gas_ip"];
+
+            //District Cooling Consumption
+            run.district_cooling_cooling_ip = run["openstudio_results.district_cooling_cooling_ip"];
+
+            // District Heating Consumption
+            run.district_heating_ip = run["openstudio_results.district_heating_ip"];
+
+            // First Year Capital Cost
+            run.first_year_cap_cost = run["openstudio_results.first_year_capital_cost"];
+
+            // Annual Utility Cost
+            run.ann_util_cost = run["openstudio_results.annual_utility_cost"];
+
+            // Total LCC
+            run.total_lcc = run["openstudio_results.total_lifecycle_cost"];
+
+            console.log(run.name);
+            console.log(run);
+            $scope.resultsWithInfo.push(run);
+
+          });
+
+        }
+      };
+
+      // Set up some additional data properties after the results
+      // are passed in.
+      $scope.setupAfterResultsAvailable = function () {
+
+        if (algorithmic) {
+          return;
+        } else {
+
+          var renderWarns = [];
+
+          // Set the energy results properties of each run
+          _.forEach($scope.results, function (run) {
+
+            // Get the OpenStudio Results measure, which contains the results
+            var reportMeasure = null;
+            _(run.steps).forEach(function (step) {
+              if (step.hasOwnProperty('result')) {
+                if (step.result.measure_uid == "a25386cd-60e4-46bc-8b11-c755f379d916") {
+                  reportMeasure = step;
+                }
+              }
+            });
+            if (!reportMeasure) {
+              renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
+              return;
+            }
+
+            // Make sure the results exist
+            if (!reportMeasure.hasOwnProperty('result')){
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
+            }
+
+            // Make sure the results have data
+            var vals = reportMeasure.result.step_values;
+            if (vals.length == 0){
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
+            }
+
+            // Make sure the EUI element exists to ensure measure was run
+            if (!_.find(vals, {'name': "eui"})) {
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
+            }
+
+            // EUI
+            run.eui = _.find(vals, {'name': "eui"}).value;
+
+            // Peak Electric Demand
+            run.peak_electric_demand_ip = _.find(vals, {'name': "annual_peak_electric_demand"}).value;
+
+            // Electricity Consumption
+            run.electricity_ip = _.find(vals, {'name': "electricity_ip"}).value;
+
+            // Natural Gas Consumption
+            run.natural_gas_ip = _.find(vals, {'name': "natural_gas_ip"}).value;
+
+            //District Cooling Consumption
+            run.district_cooling_cooling_ip = _.find(vals, {'name': "district_cooling_cooling_ip"}).value;
+
+            // District Heating Consumption
+            run.district_heating_ip = _.find(vals, {'name': "district_heating_ip"}).value;
+
+            // First Year Capital Cost
+            run.first_year_cap_cost = _.find(vals, {'name': "first_year_capital_cost"}).value;
+
+            // Annual Utility Cost
+            run.ann_util_cost = _.find(vals, {'name': "annual_utility_cost"}).value;
+
+            // Total LCC
+            run.total_lcc = _.find(vals, {'name': "total_lifecycle_cost"}).value;
+
+            console.log(run.name);
+            console.log(run);
+            $scope.resultsWithInfo.push(run);
+
+          });
+
+          // Show a unique set of warnings
+          $scope.renderWarns = _.uniq(renderWarns);
+
+        }
+
+      };
+
+    });
+
+  // set $scope.reportDir element in the report's controller from PAT project directory
+  function setReportDir(reportDir) {
+    var controllerElement = document.querySelector('div[ng-controller="MyAppCtrl"]');
+    var $scope = angular.element(controllerElement).scope();
+    console.log("Inside setReportDir");
+    $scope.$apply(function () {
+      console.log("reportDir = " + reportDir);
+      $scope.reportDir = reportDir;
+    });
+  }
+
+  // set $scope.results element in the controller above from PAT data
+  function setData(data) {
+    console.log('Setting results variable to: ', data);
+    var controllerElement = document.querySelector('div[ng-controller="MyAppCtrl"]');
+    var $scope = angular.element(controllerElement).scope();
+    $scope.$apply(function () {
+      $scope.results = data;
+      $scope.setupAfterResultsAvailable();
+    });
+  }
+
+  function setAlgorithmicData(metadata, results) {
+    console.log('Setting algorithmic results variable to: ', results);
+    var controllerElement = document.querySelector('div[ng-controller="MyAppCtrl"]');
+    var $scope = angular.element(controllerElement).scope();
+    $scope.$apply(function () {
+      $scope.algorithm_results = results;
+      $scope.algorithm_metadata = metadata;
+      $scope.setupAfterAlgorithmicResultsAvailable();
+    });
+  }
+
+</script>
+
+</body>
+</html>

--- a/app/app/reports/projectReports/Summary Table No Baseline.html
+++ b/app/app/reports/projectReports/Summary Table No Baseline.html
@@ -66,14 +66,14 @@
 
       // gather data for Algorithmic analysis
       var algorithmic = null;
-      var max_plot = 500
+      var max_plot = 500;
       $scope.setupAfterAlgorithmicResultsAvailable = function () {
         if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
           algorithmic = true;
 
           // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
           if ($scope.algorithm_results.length > max_plot + 1) {
-            $scope.renderWarns.push("Ony ploting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+            $scope.renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
             $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
           }
 

--- a/app/app/reports/projectReports/Summary Table No Baseline.html
+++ b/app/app/reports/projectReports/Summary Table No Baseline.html
@@ -75,7 +75,7 @@
 
           // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
           if ($scope.algorithm_results.length > max_plot + 1) {
-            renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+            renderWarns.push("Ony plotting " + max_plot + " algorithmic datapoints out of " + ($scope.algorithm_results.length - 1) + ".");
             $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
           }
 

--- a/app/app/reports/projectReports/Summary Table.html
+++ b/app/app/reports/projectReports/Summary Table.html
@@ -159,9 +159,12 @@
         if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
           algorithmic = true;
 
+          var renderWarns = [];
+
+
           // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
           if ($scope.algorithm_results.length > max_plot + 1) {
-            $scope.renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+            renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
             $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
           }
 
@@ -174,37 +177,74 @@
 
             // warn and skip of datapoint is missing openstudio_results
             if (!(run.hasOwnProperty('openstudio_results.total_site_eui'))){
-              $scope.renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
+              renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
               return
             }
 
             // EUI
-            //run.eui = 5;
-            run.eui = run["openstudio_results.total_site_eui"];
+            if (!run.hasOwnProperty('openstudio_results.total_site_eui')){
+              renderWarns.push("Enable total_site_eui output variable in OpenStudio Results to populate Energy Use Intensity Column.");
+            } else {
+              run.eui = run["openstudio_results.total_site_eui"];
+            }
 
             // Peak Electric Demand
-            run.peak_electric_demand_ip = run["openstudio_results.annual_peak_electric_demand"];
+            if (!run.hasOwnProperty('openstudio_results.annual_peak_electric_demand')){
+              renderWarns.push("Enable annual_peak_electric_demand output variable in OpenStudio Results to populate Peak Electricity Column.");
+            } else {
+              run.peak_electric_demand_ip = run["openstudio_results.annual_peak_electric_demand"];
+            }
 
             // Electricity Consumption
-            run.electricity_ip = run["openstudio_results.electricity_ip"];
+            if (!run.hasOwnProperty('openstudio_results.electricity_ip')){
+              renderWarns.push("Enable electricity_ip output variable in OpenStudio Results to populate Electricity Consumption Column.");
+            } else {
+              run.electricity_ip = run["openstudio_results.electricity_ip"];
+            }
 
             // Natural Gas Consumption
-            run.natural_gas_ip = run["openstudio_results.natural_gas_ip"];
+            if (!run.hasOwnProperty('openstudio_results.natural_gas_ip')){
+              renderWarns.push("Enable natural_gas_ip output variable in OpenStudio Results to populate Natural Gas Column.");
+            } else {
+              run.natural_gas_ip = run["openstudio_results.natural_gas_ip"];
+            }
 
             //District Cooling Consumption
-            run.district_cooling_cooling_ip = run["openstudio_results.district_cooling_cooling_ip"];
+            if (!run.hasOwnProperty('openstudio_results.district_cooling_cooling_ip')){
+              renderWarns.push("Enable district_cooling_cooling_ip output variable in OpenStudio Results to populate District Cooling Column.");
+            } else {
+              run.district_cooling_cooling_ip = run["openstudio_results.district_cooling_cooling_ip"];
+            }
 
             // District Heating Consumption
-            run.district_heating_ip = run["openstudio_results.district_heating_ip"];
+            if (!run.hasOwnProperty('openstudio_results.district_heating_ip')){
+              renderWarns.push("Enable district_heating_ip output variable in OpenStudio Results to populate District Heating Column.");
+            } else {
+              run.district_heating_ip = run["openstudio_results.district_heating_ip"];
+            }
 
             // First Year Capital Cost
-            run.first_year_cap_cost = run["openstudio_results.first_year_capital_cost"];
+            if (!run.hasOwnProperty('openstudio_results.first_year_capital_cost')){
+              renderWarns.push("Enable first_year_capital_cost output variable in OpenStudio Results to populate First Year Capital Cost Column.");
+            } else {
+              run.first_year_cap_cost = run["openstudio_results.first_year_capital_cost"];
+            }
 
             // Annual Utility Cost
-            run.ann_util_cost = run["openstudio_results.annual_utility_cost"];
+            if (!run.hasOwnProperty('openstudio_results.annual_utility_cost')){
+              renderWarns.push("Enable annual_utility_cost output variable in OpenStudio Results to populate Annual Utility Cost Column.");
+            } else {
+              run.ann_util_cost = run["openstudio_results.annual_utility_cost"];
+            }
 
             // Total LCC
             run.total_lcc = run["openstudio_results.total_lifecycle_cost"];
+
+            if (!run.hasOwnProperty('openstudio_results.total_lifecycle_cost')){
+              renderWarns.push("Enable total_lifecycle_cost output variable in OpenStudio Results to populate Total Lifecycle Cost Column.");
+            } else {
+              run.total_lcc = run["openstudio_results.total_lifecycle_cost"];
+            }
 
             console.log(run.name);
             console.log(run);
@@ -217,6 +257,9 @@
             $scope.baseline = $scope.resultsWithInfo.reverse()[0];
             $scope.baseline_name = $scope.baseline.name;
           }
+
+          // Show a unique set of warnings
+          $scope.renderWarns = _.uniq(renderWarns);
 
         }
       };

--- a/app/app/reports/projectReports/Summary Table.html
+++ b/app/app/reports/projectReports/Summary Table.html
@@ -164,7 +164,7 @@
 
           // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
           if ($scope.algorithm_results.length > max_plot + 1) {
-            renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+            renderWarns.push("Ony plotting " + max_plot + " algorithmic datapoints out of " + ($scope.algorithm_results.length - 1) + ".");
             $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
           }
 
@@ -246,8 +246,8 @@
               run.total_lcc = run["openstudio_results.total_lifecycle_cost"];
             }
 
-            console.log(run.name);
-            console.log(run);
+            //console.log(run.name);
+            //console.log(run);
             $scope.resultsWithInfo.push(run);
 
           });

--- a/app/app/reports/projectReports/Summary Table.html
+++ b/app/app/reports/projectReports/Summary Table.html
@@ -154,7 +154,7 @@
 
       // gather data for Algorithmic analysis
       var algorithmic = null;
-      var max_plot = 500;
+      var max_plot = 1000;
       $scope.setupAfterAlgorithmicResultsAvailable = function () {
         if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
           algorithmic = true;

--- a/app/app/reports/projectReports/Summary Table.html
+++ b/app/app/reports/projectReports/Summary Table.html
@@ -154,14 +154,14 @@
 
       // gather data for Algorithmic analysis
       var algorithmic = null;
-      var max_plot = 500
+      var max_plot = 500;
       $scope.setupAfterAlgorithmicResultsAvailable = function () {
         if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
           algorithmic = true;
 
           // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
           if ($scope.algorithm_results.length > max_plot + 1) {
-            $scope.renderWarns.push("Ony ploting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+            $scope.renderWarns.push("Ony plotting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
             $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
           }
 

--- a/app/app/reports/projectReports/Summary Table.html
+++ b/app/app/reports/projectReports/Summary Table.html
@@ -77,13 +77,13 @@
             <li ng-repeat="measure_name in run.measure_names">{{ measure_name }}</li>
           </ul>
         </td>
-        <td>{{ baseline.eui - run.eui | number:1}} <br> {{ calculateEuiReductionPercentage(baseline.eui, run.eui) | number:0}}%</td>
+        <td>{{ baseline.eui - run.eui | number:1}} <br> {{ calculateReductionPercentage(baseline.eui, run.eui) | number:0}}%</td>
         <td>{{ baseline.peak_electric_demand_ip - run.peak_electric_demand_ip | number:1}} <br> {{
           100*(baseline.peak_electric_demand_ip - run.peak_electric_demand_ip)/baseline.peak_electric_demand_ip |
           number:0}}%
         </td>
-        <td>{{ baseline.electricity_ip - run.electricity_ip | number:1}} <br> {{ 100*(baseline.electricity_ip -
-          run.electricity_ip)/baseline.electricity_ip | number:0}}%
+        <td>{{ baseline.electricity_ip - run.electricity_ip | number:1}} <br> {{
+          calculateReductionPercentage(baseline.electricity_ip, run.electricity_ip) | number:0}}%
         </td>
         <td>{{ baseline.natural_gas_ip - run.natural_gas_ip | number:1}} <br> {{ 100*(baseline.natural_gas_ip -
           run.natural_gas_ip)/baseline.natural_gas_ip | number:0}}%
@@ -130,8 +130,8 @@
       // Show any issues
       $scope.renderWarns = [];
 
-      $scope.calculateEuiReductionPercentage = function (baseline_eui, run_eui) {
-        return (100*(baseline_eui - run_eui)/baseline_eui );
+      $scope.calculateReductionPercentage = function (baseline_val, run_val) {
+        return (100*(baseline_val - run_val)/(Math.abs(baseline_val)) );
       };
 
       // Update the baseline based on the selected name

--- a/app/app/reports/projectReports/Summary Table.html
+++ b/app/app/reports/projectReports/Summary Table.html
@@ -131,134 +131,215 @@
       $scope.renderWarns = [];
 
       // Update the baseline based on the selected name
+      // todo - update this to work with manual or algorithmic
       $scope.updateBaseline = function () {
-        _.forEach($scope.results, function (run) {
-          if (run.name == $scope.baseline_name) {
-            $scope.baseline = run;
-            console.log('Changed baseline to ' + $scope.baseline.name);
+
+        if (algorithmic) {
+          _.forEach($scope.algorithm_results, function (run) {
+            if (run.name == $scope.baseline_name) {
+              $scope.baseline = run;
+              console.log('Changed baseline to ' + $scope.baseline.name);
+            }
+          });
+        } else {
+          _.forEach($scope.results, function (run) {
+            if (run.name == $scope.baseline_name) {
+              $scope.baseline = run;
+              console.log('Changed baseline to ' + $scope.baseline.name);
+            }
+          });
+        }
+
+      };
+
+      // gather data for Algorithmic analysis
+      var algorithmic = null;
+      var max_plot = 500
+      $scope.setupAfterAlgorithmicResultsAvailable = function () {
+        if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
+          algorithmic = true;
+
+          // limit datapoints to max_plot (+ 1 used in if statement and -1 message because of empty last object in algorithmic_results
+          if ($scope.algorithm_results.length > max_plot + 1) {
+            $scope.renderWarns.push("Ony ploting " + max_plot + " algorhtimic dataopints out of " + ($scope.algorithm_results.length - 1) + ".");
+            $scope.algorithm_results = $scope.algorithm_results.slice(0,max_plot)
           }
-        });
+
+          // Set the energy results properties of each run
+          _.forEach($scope.algorithm_results, function (run) {
+
+            if (run.name === "") {
+              return
+            }
+
+            // warn and skip of datapoint is missing openstudio_results
+            if (!(run.hasOwnProperty('openstudio_results.total_site_eui'))){
+              $scope.renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
+              return
+            }
+
+            // EUI
+            //run.eui = 5;
+            run.eui = run["openstudio_results.total_site_eui"];
+
+            // Peak Electric Demand
+            run.peak_electric_demand_ip = run["openstudio_results.annual_peak_electric_demand"];
+
+            // Electricity Consumption
+            run.electricity_ip = run["openstudio_results.electricity_ip"];
+
+            // Natural Gas Consumption
+            run.natural_gas_ip = run["openstudio_results.natural_gas_ip"];
+
+            //District Cooling Consumption
+            run.district_cooling_cooling_ip = run["openstudio_results.district_cooling_cooling_ip"];
+
+            // District Heating Consumption
+            run.district_heating_ip = run["openstudio_results.district_heating_ip"];
+
+            // First Year Capital Cost
+            run.first_year_cap_cost = run["openstudio_results.first_year_capital_cost"];
+
+            // Annual Utility Cost
+            run.ann_util_cost = run["openstudio_results.annual_utility_cost"];
+
+            // Total LCC
+            run.total_lcc = run["openstudio_results.total_lifecycle_cost"];
+
+            console.log(run.name);
+            console.log(run);
+            $scope.resultsWithInfo.push(run);
+
+          });
+
+          // Make the comparison point the first run to start
+          if ($scope.resultsWithInfo.length > 0) {
+            $scope.baseline = $scope.resultsWithInfo.reverse()[0];
+            $scope.baseline_name = $scope.baseline.name;
+          }
+
+        }
       };
 
       // Set up some additional data properties after the results
       // are passed in.
       $scope.setupAfterResultsAvailable = function () {
 
-        var renderWarns = [];
 
-        // Get the unique measure counts
-        // based on unique name + argument values.
-        var measureCounts = {};
-        var numAlts = 0;
-        _.forEach($scope.results, function (run) {
-          numAlts += 1;
-          _.forEach(run.steps, function (step) {
-            // Make sure the results exist
-            if (!step.hasOwnProperty('result')){
+        if (algorithmic) {
+          return;
+        } else {
+
+          var renderWarns = [];
+
+          // Get the unique measure counts
+          // based on unique name + argument values.
+          var measureCounts = {};
+          var numAlts = 0;
+          _.forEach($scope.results, function (run) {
+            numAlts += 1;
+            _.forEach(run.steps, function (step) {
+              // Make sure the results exist
+              if (!step.hasOwnProperty('result')){
+                return;
+              }
+              var idPlusArgs = step.result.measure_uid + JSON.stringify(step.arguments);
+              step.idPlusArgs = idPlusArgs;
+              if (measureCounts[idPlusArgs]) {
+                measureCounts[idPlusArgs] += 1;
+              } else {
+                measureCounts[idPlusArgs] = 1;
+              }
+            });
+          });
+          console.info("There are results for " + numAlts + " runs");
+
+          // Set the measure_names property of each run
+          _.forEach($scope.results, function (run) {
+            run.measure_names = measureNames(run, measureCounts, numAlts);
+          });
+
+          // Set the energy results properties of each run
+          _.forEach($scope.results, function (run) {
+
+            // Get the OpenStudio Results measure, which contains the results
+            var reportMeasure = null;
+            _(run.steps).forEach(function (step) {
+              if (step.hasOwnProperty('result')) {
+                if (step.result.measure_uid == "a25386cd-60e4-46bc-8b11-c755f379d916") {
+                  reportMeasure = step;
+                }
+              }
+            });
+            if (!reportMeasure) {
+              renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
               return;
             }
-            var idPlusArgs = step.result.measure_uid + JSON.stringify(step.arguments);
-            step.idPlusArgs = idPlusArgs;
-            if (measureCounts[idPlusArgs]) {
-              measureCounts[idPlusArgs] += 1;
-            } else {
-              measureCounts[idPlusArgs] = 1;
+
+            // Make sure the results exist
+            if (!reportMeasure.hasOwnProperty('result')){
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
             }
-          });
-        });
-        console.info("There are results for " + numAlts + " runs");
 
-        // Set the measure_names property of each run
-        _.forEach($scope.results, function (run) {
-          run.measure_names = measureNames(run, measureCounts, numAlts);
-        });
-
-        // Set the energy results properties of each run
-        _.forEach($scope.results, function (run) {
-
-          // Get the OpenStudio Results measure, which contains the results
-          var reportMeasure = null;
-          _(run.steps).forEach(function (step) {
-            if (step.hasOwnProperty('result')) {
-              if (step.result.measure_uid == "a25386cd-60e4-46bc-8b11-c755f379d916") {
-                reportMeasure = step;
-              }
+            // Make sure the results have data
+            var vals = reportMeasure.result.step_values;
+            if (vals.length == 0){
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
             }
+
+            // Make sure the EUI element exists to ensure measure was run
+            if (!_.find(vals, {'name': "eui"})) {
+              renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
+              return;
+            }
+
+            run.eui = _.find(vals, {'name': "eui"}).value;
+
+            // Peak Electric Demand
+            run.peak_electric_demand_ip = _.find(vals, {'name': "annual_peak_electric_demand"}).value;
+
+            // Electricity Consumption
+            run.electricity_ip = _.find(vals, {'name': "electricity_ip"}).value;
+
+            // Natural Gas Consumption
+            run.natural_gas_ip = _.find(vals, {'name': "natural_gas_ip"}).value;
+
+            //District Cooling Consumption
+            run.district_cooling_cooling_ip = _.find(vals, {'name': "district_cooling_cooling_ip"}).value;
+
+            // District Heating Consumption
+            run.district_heating_ip = _.find(vals, {'name': "district_heating_ip"}).value;
+
+            // First Year Capital Cost
+            run.first_year_cap_cost = _.find(vals, {'name': "first_year_capital_cost"}).value;
+
+            // Annual Utility Cost
+            run.ann_util_cost = _.find(vals, {'name': "annual_utility_cost"}).value;
+
+            // Total LCC
+            run.total_lcc = _.find(vals, {'name': "total_lifecycle_cost"}).value;
+
+            console.log(run.name);
+            console.log(run);
+            $scope.resultsWithInfo.push(run);
+
           });
-          if (!reportMeasure) {
-            renderWarns.push("The OpenStudio Results measure was not included in " + run.name + ", cannot show results.");
-            return;
+
+          // Make the comparison point the first run to start
+          if ($scope.resultsWithInfo.length > 0) {
+            $scope.baseline = $scope.resultsWithInfo.reverse()[0];
+            $scope.baseline_name = $scope.baseline.name;
           }
 
-          // Make sure the results exist
-          if (!reportMeasure.hasOwnProperty('result')){
-            renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
-            return;
-          }
+          // Show a unique set of warnings
+          _.forEach(_.uniq(renderWarns), function (warn) {
+            $scope.renderWarns.push(warn);
+          });
 
-          // Make sure the results have data
-          var vals = reportMeasure.result.step_values;
-          if (vals.length == 0){
-            renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
-            return;
-          }
-
-          // Make sure the EUI element exists to ensure measure was run
-          if (!_.find(vals, {'name': "eui"})) {
-            renderWarns.push("The OpenStudio Results measure was not run in " + run.name + ", cannot show results.");
-            return;
-          }
-
-          run.eui = _.find(vals, {'name': "eui"}).value;
-
-          // Peak Electric Demand
-          run.peak_electric_demand_ip = _.find(vals, {'name': "annual_peak_electric_demand"}).value;
-
-          // Electricity Consumption
-          run.electricity_ip = _.find(vals, {'name': "electricity_ip"}).value;
-
-          // Natural Gas Consumption
-          run.natural_gas_ip = _.find(vals, {'name': "natural_gas_ip"}).value;
-
-          //District Cooling Consumption
-          run.district_cooling_cooling_ip = _.find(vals, {'name': "district_cooling_cooling_ip"}).value;
-
-          // District Heating Consumption
-          run.district_heating_ip = _.find(vals, {'name': "district_heating_ip"}).value;
-
-          // First Year Capital Cost
-          run.first_year_cap_cost = _.find(vals, {'name': "first_year_capital_cost"}).value;
-
-          // Annual Utility Cost
-          run.ann_util_cost = _.find(vals, {'name': "annual_utility_cost"}).value;
-
-          // Total LCC
-          run.total_lcc = _.find(vals, {'name': "total_lifecycle_cost"}).value;
-
-          console.log(run.name);
-          console.log(run);
-          $scope.resultsWithInfo.push(run);
-
-        });
-
-        // Make the comparison point the first run to start
-        if ($scope.resultsWithInfo.length > 0) {
-          $scope.baseline = $scope.resultsWithInfo.reverse()[0];
-          $scope.baseline_name = $scope.baseline.name;
         }
 
-        // Show a unique set of warnings
-        _.forEach(_.uniq(renderWarns), function (warn) {
-          $scope.renderWarns.push(warn);
-        });
-
-      };
-
-      // Warn user that this report doesn't work in Algorithmic mode
-      $scope.setupAfterAlgorithmicResultsAvailable = function () {
-        if ( $scope.algorithm_results.length > 0 || $scope.algorithm_metadata.length > 0 ) {
-          $scope.renderWarns.push("This report will only work with Analysis Type = Manual.");
-        }
       };
 
     });
@@ -325,8 +406,8 @@
     var controllerElement = document.querySelector('div[ng-controller="MyAppCtrl"]');
     var $scope = angular.element(controllerElement).scope();
     $scope.$apply(function () {
-      $scope.algorithm_results = metadata;
-      $scope.algorithm_metadata = results;
+      $scope.algorithm_results = results;
+      $scope.algorithm_metadata = metadata;
       $scope.setupAfterAlgorithmicResultsAvailable();
     });
   }

--- a/app/app/reports/projectReports/Summary Table.html
+++ b/app/app/reports/projectReports/Summary Table.html
@@ -77,7 +77,7 @@
             <li ng-repeat="measure_name in run.measure_names">{{ measure_name }}</li>
           </ul>
         </td>
-        <td>{{ baseline.eui - run.eui | number:1}} <br> {{ 100*(baseline.eui - run.eui)/baseline.eui | number:0}}%</td>
+        <td>{{ baseline.eui - run.eui | number:1}} <br> {{ calculateEuiReductionPercentage(baseline.eui, run.eui) | number:0}}%</td>
         <td>{{ baseline.peak_electric_demand_ip - run.peak_electric_demand_ip | number:1}} <br> {{
           100*(baseline.peak_electric_demand_ip - run.peak_electric_demand_ip)/baseline.peak_electric_demand_ip |
           number:0}}%
@@ -129,6 +129,10 @@
 
       // Show any issues
       $scope.renderWarns = [];
+
+      $scope.calculateEuiReductionPercentage = function (baseline_eui, run_eui) {
+        return (100*(baseline_eui - run_eui)/baseline_eui );
+      };
 
       // Update the baseline based on the selected name
       // todo - update this to work with manual or algorithmic

--- a/app/app/reports/reportsController.js
+++ b/app/app/reports/reportsController.js
@@ -129,9 +129,9 @@ export class ReportsController {
     };
 
     // Uncomment this to view webview developer tools to debug project reports
-    if (vm.env != 'production') {
-      vm.openWebViewDevTools();
-    }
+    //if (vm.env != 'production') {
+    //  vm.openWebViewDevTools();
+    //}
 
     //pass data into webview when dom is ready
     angular.element(document).ready(function () {

--- a/app/app/reports/reportsController.js
+++ b/app/app/reports/reportsController.js
@@ -129,9 +129,9 @@ export class ReportsController {
     };
 
     // Uncomment this to view webview developer tools to debug project reports
-    // if (vm.env != 'production') {
-    //   vm.openWebViewDevTools();
-    // }
+    if (vm.env != 'production') {
+      vm.openWebViewDevTools();
+    }
 
     //pass data into webview when dom is ready
     angular.element(document).ready(function () {
@@ -154,8 +154,8 @@ export class ReportsController {
     const vm = this;
     var wv = document.getElementById('wv');
     wv.executeJavaScript(`setReportDir(${JSON.stringify(vm.reportDirPath)});`);
-    wv.executeJavaScript(`setData(${JSON.stringify(vm.testResults)});`);
     wv.executeJavaScript(`setAlgorithmicData(${JSON.stringify(vm.algorithmic_metadata)}, ${JSON.stringify(vm.algorithmic_results)});`);
+    wv.executeJavaScript(`setData(${JSON.stringify(vm.testResults)});`);
   }
 
 }

--- a/app/app/reports/reportsController.js
+++ b/app/app/reports/reportsController.js
@@ -129,9 +129,9 @@ export class ReportsController {
     };
 
     // Uncomment this to view webview developer tools to debug project reports
-    //if (vm.env != 'production') {
+    // if (vm.env != 'production') {
     //  vm.openWebViewDevTools();
-    //}
+    // }
 
     //pass data into webview when dom is ready
     angular.element(document).ready(function () {
@@ -153,9 +153,13 @@ export class ReportsController {
   passData() {
     const vm = this;
     var wv = document.getElementById('wv');
-    wv.executeJavaScript(`setReportDir(${JSON.stringify(vm.reportDirPath)});`);
-    wv.executeJavaScript(`setAlgorithmicData(${JSON.stringify(vm.algorithmic_metadata)}, ${JSON.stringify(vm.algorithmic_results)});`);
-    wv.executeJavaScript(`setData(${JSON.stringify(vm.testResults)});`);
+
+    wv.addEventListener('dom-ready', function () {
+      wv.executeJavaScript(`setReportDir(${JSON.stringify(vm.reportDirPath)});`);
+      wv.executeJavaScript(`setAlgorithmicData(${JSON.stringify(vm.algorithmic_metadata)}, ${JSON.stringify(vm.algorithmic_results)});`);
+      wv.executeJavaScript(`setData(${JSON.stringify(vm.testResults)});`);
+    });
+
   }
 
 }


### PR DESCRIPTION
Updated "Summary Table" script to support algorithmic runs, and added a new "Summary Table with no Baseline" script. I cleaned up warning for EDAPT and End Use Comparison but didn't' enable for algorithmic because they are not a good fit for it. End use could be adapted to do this.

The only limitation of "Summary Table" is that there isn't a reliable way to get a list of measure, so that column is left blank. I could look find measures with arguments or output variables but they won't be "Measure Options" like manual run.

There is an additional user requirement for algorithmic model In addition to including "OpenStudio Results" which is needed for manual, the modeler also needs to enable output variables. As shown in the images below a warning shows indicating which variable are missing.

For now the measure caps at 500 datapoints and issues a warning that not all are shown, but this can probably be increased.

![screen shot 2018-01-30 at 2 24 35 pm](https://user-images.githubusercontent.com/4857055/35593705-e0201122-05cd-11e8-8c13-3f5056300410.png)

![screen shot 2018-01-30 at 2 26 39 pm](https://user-images.githubusercontent.com/4857055/35593716-e77a04dc-05cd-11e8-8ea3-c1c52832df91.png)

![screen shot 2018-01-30 at 2 31 22 pm](https://user-images.githubusercontent.com/4857055/35593728-efc7a180-05cd-11e8-8f59-50eac56c44ab.png)
