### PR TITLE
Fix for #56 -PAT for Ubuntu

### DIFF
--- a/app/app/main/dependencyManagerService.js
+++ b/app/app/main/dependencyManagerService.js
@@ -74,8 +74,10 @@ export class DependencyManager {
     if (os.platform() == 'win32') {
       exeExt = '.exe';
     }
-    let bindingExt = '.bundle';
+    let bindingExt = '.bundle'; // darwin
     if (os.platform() == 'win32') {
+      bindingExt = '.so';
+    } else if (os.platform() == 'linux') {
       bindingExt = '.so';
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -76,7 +76,7 @@
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-c629d77ff1-linux.tar.gz",
+    "name": "OpenStudio-server-e0cf8a8219-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio-server"

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
     "arch": "x64",
     "type": "ruby"
   }, {
-    "name": "ruby-2.2.4-linux.tar.gz",
+    "name": "http://openstudio-resources.s3.amazonaws.com/dependencies/ruby_2_2_4_linux_static.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "ruby"
@@ -49,7 +49,7 @@
     "arch": "x64",
     "type": "mongo"
   }, {
-    "name": "mongodb-linux-x86_64-3.2.5.tgz",
+    "name": "http://downloads.mongodb.org/linux/mongodb-linux-x86_64-3.2.5.tgz",
     "platform": "linux",
     "arch": "x64",
     "type": "mongo"

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,11 @@
     "platform": "darwin",
     "arch": "x64",
     "type": "energyplus"
+  }, {
+    "name": "https://github.com/NREL/EnergyPlus/releases/download/v9.3.0/EnergyPlus-9.3.0-baff08990c-Linux-x86_64.tar.gz",
+    "platform": "linux",
+    "arch": "x64",
+    "type": "energyplus"
   }],
   "perl": [{
     "name": "perl-5.16.2-win32.tar.gz",
@@ -33,7 +38,7 @@
     "arch": "x64",
     "type": "ruby"
   }, {
-    "name": "http://openstudio-resources.s3.amazonaws.com/dependencies/ruby_2_2_4_linux_static.tar.gz",
+    "name": "ruby-2.5.5-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "ruby"
@@ -49,7 +54,7 @@
     "arch": "x64",
     "type": "mongo"
   }, {
-    "name": "http://downloads.mongodb.org/linux/mongodb-linux-x86_64-3.2.5.tgz",
+    "name": "http://downloads.mongodb.org/linux/mongodb-linux-x86_64-3.6.3.tgz",
     "platform": "linux",
     "arch": "x64",
     "type": "mongo"
@@ -64,6 +69,11 @@
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
+  }, {
+    "name": "https://github.com/NREL/OpenStudio/releases/download/v3.0.0/OpenStudio-3.0.0+1c9617fa4e-Linux.tar.gz",
+    "platform": "linux",
+    "arch": "x64",
+    "type": "openstudio"
   }],
   "openstudioServer": [{
     "name": "OpenStudio-server-b7df23d15e-win32.tar.gz",
@@ -76,7 +86,7 @@
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-e0cf8a8219-linux.tar.gz",
+    "name": "OpenStudio-server-a43d33438a-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio-server"

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,11 @@
     "platform": "darwin",
     "arch": "x64",
     "type": "ruby"
+  }, {
+    "name": "ruby-2.2.4-linux.tar.gz",
+    "platform": "linux",
+    "arch": "x64",
+    "type": "ruby"
   }],
   "mongo": [{
     "name": "mongodb-3.2.5-win32.tar.gz",
@@ -41,6 +46,11 @@
   }, {
     "name": "mongodb-3.6.3-darwin.tar.gz",
     "platform": "darwin",
+    "arch": "x64",
+    "type": "mongo"
+  }, {
+    "name": "mongodb-linux-x86_64-3.2.5.tgz",
+    "platform": "linux",
     "arch": "x64",
     "type": "mongo"
   }],
@@ -63,6 +73,11 @@
   }, {
     "name": "OpenStudio-server-b7df23d15e-darwin.tar.gz",
     "platform": "darwin",
+    "arch": "x64",
+    "type": "OpenStudio-server"
+  }, {
+    "name": "OpenStudio-server-c629d77ff1-linux.tar.gz",
+    "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio-server"
   }]

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -13,7 +13,7 @@ var os = require('os');
 var decompress = require('gulp-decompress');
 var clean = require('gulp-clean');
 var merge = require('merge-stream');
-
+var rename = require("gulp-rename");
 
 var $ = require('gulp-load-plugins')({
   pattern: ['gulp-*', 'main-bower-files', 'del', 'lazypipe', 'streamify']
@@ -157,6 +157,8 @@ gulp.task('download-deps', function () {
     const fileInfo = _.find(manifest[depend], {platform: platform});
     const fileName = fileInfo.name;
 
+    // Note JM 2018-09-13: Allow other resources in case AWS isn't up to date
+    // and for easier testing of new deps
     if( fileName.includes("http") ) {
       // Already a URI
       var uri = fileName;
@@ -166,6 +168,7 @@ gulp.task('download-deps', function () {
       var uri = manifest.endpoint + fileName;
       var destName = fileName;
     }
+
     return progress(request({uri: uri, timeout: 5000}))
       .on('progress', state => {
         console.log(`Downloading ${depend}, ${(state.percentage * 100).toFixed(0)}%`);
@@ -188,10 +191,17 @@ gulp.task('extract-deps', ['download-deps'], function () {
       var destName = fileName;
     }
 
-    return gulp.src(path.join(destination, fileName))
-      .pipe(decompress())
-      .pipe(gulp.dest(destination));
-  });
+    // Note JM 2018-0913:
+    // Usually deps are properly zipped to that the extracted root folder
+    // is adequately named, but when using absolute http:// resources (not
+    // packaged specifically by us), we must rename to ensure it's correct
+    var properName = fileInfo.type;
+
+    // What we do is to extract to properName and remove the leading (root)
+    // directory level
+    return gulp.src(path.join(destination, destName))
+      .pipe( decompress({strip: 1}) )
+      .pipe(gulp.dest(path.join(destination, properName)));  });
 
   return merge(tasks);
 });
@@ -216,7 +226,3 @@ gulp.task('remove-deps-tar', ['extract-deps'], function () {
 
 gulp.task('install-deps', ['remove-deps-tar'], function () {
 });
-
-
-
-

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -157,11 +157,20 @@ gulp.task('download-deps', function () {
     const fileInfo = _.find(manifest[depend], {platform: platform});
     const fileName = fileInfo.name;
 
-    return progress(request({uri: manifest.endpoint + fileName, timeout: 5000}))
+    if( fileName.includes("http") ) {
+      // Already a URI
+      var uri = fileName;
+      var destName = fileName.replace(/^.*[\\\/]/, '');
+    } else {
+      // Need to concat endpoint (AWS) with the fileName
+      var uri = manifest.endpoint + fileName;
+      var destName = fileName;
+    }
+    return progress(request({uri: uri, timeout: 5000}))
       .on('progress', state => {
         console.log(`Downloading ${depend}, ${(state.percentage * 100).toFixed(0)}%`);
       })
-      .pipe(source(fileName))
+      .pipe(source(destName))
       .pipe(gulp.dest(destination));
   });
 
@@ -172,6 +181,12 @@ gulp.task('extract-deps', ['download-deps'], function () {
   var tasks = dependencies.map(depend => {
     const fileInfo = _.find(manifest[depend], {platform: platform});
     const fileName = fileInfo.name;
+
+    if( fileName.includes("http") ) {
+      var destName = fileName.replace(/^.*[\\\/]/, '');
+    } else {
+      var destName = fileName;
+    }
 
     return gulp.src(path.join(destination, fileName))
       .pipe(decompress())
@@ -185,6 +200,12 @@ gulp.task('remove-deps-tar', ['extract-deps'], function () {
   var tasks = dependencies.map(depend => {
     const fileInfo = _.find(manifest[depend], {platform: platform});
     const fileName = fileInfo.name;
+
+    if( fileName.includes("http") ) {
+      var destName = fileName.replace(/^.*[\\\/]/, '');
+    } else {
+      var destName = fileName;
+    }
 
     return gulp.src(path.join(destination, fileName), {read: false})
       .pipe(clean());


### PR DESCRIPTION
@macumber This is a work in progress regarding #56. I think there's a problem with the ruby dependency I currently load from OpenStudio AWS since it's not **relocatable**.

But at least this allows building the PAT application and running `npm run start`.

Changelog so far:
* Initial commit is the manifest.json as it should be in the end, once dependencies are uploaded (missing mongo and proper ruby relocatable currently)
* Enabled add non AWS resources in manifest.json: pass a full `http://path/to/file.tar.gz` and it'll download that and extract it with a proper name (dependencies specifically build by the team have the root folder with the right name when extracting, online deps may not)