### PR TITLE
Update manifest to use OpenStudio-3.0.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -60,17 +60,17 @@
     "type": "mongo"
   }],
   "openstudio": [{
-    "name": "OpenStudio-3.0.1-rc2-Windows.tar.gz",
+    "name": "OpenStudio-3.0.1-Windows.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.0.1-rc2-Darwin.tar.gz",
+    "name": "OpenStudio-3.0.1-Darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.0.1-rc2-Linux.tar.gz",
+    "name": "OpenStudio-3.0.1-Linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio"

--- a/manifest.json
+++ b/manifest.json
@@ -60,17 +60,17 @@
     "type": "mongo"
   }],
   "openstudio": [{
-    "name": "OpenStudio-3.0.1-rc1-Windows.tar.gz",
+    "name": "OpenStudio-3.0.1-rc2-Windows.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.0.1-rc1-Darwin.tar.gz",
+    "name": "OpenStudio-3.0.1-rc2-Darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.0.1-rc1-Linux.tar.gz",
+    "name": "OpenStudio-3.0.1-rc2-Linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio"


### PR DESCRIPTION
Updating manifest deps to use OpenStudio v3.0.1-rc2. 

CI builds this branch successfully on all 3 platforms: 

https://ci.commercialbuildings.dev/blue/organizations/jenkins/pat-nightly/detail/pat-nightly/17/

