### PR TITLE
Patch execjs gem for osx 10.15

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -81,7 +81,7 @@
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-f1b8acbc52-darwin.tar.gz",
+    "name": "OpenStudio-server-f1b8acbc52-patch-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "OpenStudio-server"


### PR DESCRIPTION
This is patch to the openstuio-server gems it to fix #159. 

Once this PR is included this will fix the next server gem build. 
https://github.com/rails/execjs/pull/89 

If this doesn't get updated by next release cycle, we'll need to fork our own gem of this or apply patch file during gem build process. 

