### PR TITLE
Update to mongo 4.4.2 for all platforms

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -44,17 +44,17 @@
     "type": "ruby"
   }],
   "mongo": [{
-    "name": "mongodb-3.2.5-win32.tar.gz",
+    "name": "mongodb-4.4.2-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "mongo"
   }, {
-    "name": "mongodb-3.6.3-darwin.tar.gz",
+    "name": "mongodb-4.4.2-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "mongo"
   }, {
-    "name": "mongodb-3.6.3-linux.tar.gz",
+    "name": "mongodb-4.4.2-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "mongo"


### PR DESCRIPTION
resolves #173 

Update to Mongo 4.4.2 for all platforms.  Note that the Mongo recently separated the tools and db sever into separate installation packages.  

Tools: https://www.mongodb.com/try/download/database-tools
Server:  https://www.mongodb.com/try/download/community

The s3 tar packages in the manifest combines the server and tools into one .tar.gz, like we had before, so we shouldn't have to make any code changes for new paths.  



