### PR TITLE
Update Openstudio SDK 3.2.0-rc1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14.0)
 cmake_policy(SET CMP0048 NEW)
 
-project(ParametricAnalysisTool VERSION 3.1.0)
+project(ParametricAnalysisTool VERSION 3.2.0)
 
 find_package(Git)
 
@@ -93,7 +93,7 @@ if(UNIX AND NOT APPLE)
   set(CPACK_SET_DESTDIR ON)
   set(CPACK_INSTALL_PREFIX "/usr/local/${CPACK_PACKAGE_INSTALL_DIRECTORY}/")
   # ruby on ubuntu (18.04) uses libqdbm14
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqdbm14") 
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqdbm14")
 elseif(APPLE)
   set(CPACK_IFW_TARGET_DIRECTORY "/Applications/${CPACK_PACKAGE_INSTALL_DIRECTORY}/")
   set(CPACK_BINARY_STGZ OFF CACHE BOOL "Enable to build STGZ packages")

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "ParametricAnalysisTool",
   "identifier": "gov.nrel.openstudio.pat",
   "description": "OpenStudio Parametric Analysis Tool",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "National Renewable Energy Laboratory",
   "main": "background.js",
   "dependencies": {

--- a/manifest.json
+++ b/manifest.json
@@ -60,33 +60,33 @@
     "type": "mongo"
   }],
   "openstudio": [{
-    "name": "OpenStudio-3.1.1-Windows.tar.gz",
+    "name": "OpenStudio-3.2.0-rc1-Windows.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.1.1-Darwin.tar.gz",
+    "name": "OpenStudio-3.2.0-rc1-Darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.1.1-Linux.tar.gz",
+    "name": "OpenStudio-3.2.0-rc1-Linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio"
   }],
   "openstudioServer": [{
-    "name": "OpenStudio-server-518fa90391-win32.tar.gz",
+    "name": "OpenStudio-server-cc4a9f9ada-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-518fa90391-darwin.tar.gz",
+    "name": "OpenStudio-server-cc4a9f9ada-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-518fa90391-linux.tar.gz",
+    "name": "OpenStudio-server-cc4a9f9ada-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio-server"

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,17 @@
 {
   "endpoint": "https://openstudio-resources.s3.amazonaws.com/pat-dependencies3/",
   "energyplus": [{
-    "name": "EnergyPlus-9.4.0-win32.tar.gz",
+    "name": "EnergyPlus-9.5.0-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "energyplus"
   }, {
-    "name": "EnergyPlus-9.4.0-darwin.tar.gz",
+    "name": "EnergyPlus-9.5.0-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "energyplus"
   }, {
-    "name": "EnergyPlus-9.4.0-linux.tar.gz",
+    "name": "EnergyPlus-9.5.0-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "energyplus"
@@ -28,17 +28,17 @@
     "type": "perl"
   }],
   "ruby": [{
-    "name": "ruby-2.5.5-win32.tar.gz",
+    "name": "ruby-2.7.2-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "ruby"
   }, {
-    "name": "ruby-2.5.5-darwin.tar.gz",
+    "name": "ruby-2.7.2-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "ruby"
   }, {
-    "name": "ruby-2.5.5-linux.tar.gz",
+    "name": "ruby-2.7.2-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "ruby"
@@ -60,33 +60,33 @@
     "type": "mongo"
   }],
   "openstudio": [{
-    "name": "OpenStudio-3.1.0-Windows.tar.gz",
+    "name": "OpenStudio-3.1.1-Windows.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.1.0-Darwin.tar.gz",
+    "name": "OpenStudio-3.1.1-Darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.1.0-Linux.tar.gz",
+    "name": "OpenStudio-3.1.1-Linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio"
   }],
   "openstudioServer": [{
-    "name": "OpenStudio-server-2f13b361e8-win32.tar.gz",
+    "name": "OpenStudio-server-7107f4704a-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-2f13b361e8-darwin.tar.gz",
+    "name": "OpenStudio-server-7107f4704a-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-2f13b361e8-linux.tar.gz",
+    "name": "OpenStudio-server-7107f4704a-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio-server"

--- a/manifest.json
+++ b/manifest.json
@@ -76,17 +76,17 @@
     "type": "OpenStudio"
   }],
   "openstudioServer": [{
-    "name": "OpenStudio-server-7107f4704a-win32.tar.gz",
+    "name": "OpenStudio-server-518fa90391-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-7107f4704a-darwin.tar.gz",
+    "name": "OpenStudio-server-518fa90391-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-7107f4704a-linux.tar.gz",
+    "name": "OpenStudio-server-518fa90391-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio-server"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openstudio-pat",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "devDependencies": {
     "asar": "~0.10.0",
     "babel-core": "~6.7.5",


### PR DESCRIPTION
This updates the manifest to use Openstudio 3.2.0-rc1, server gems and Energyplus to 9.5
