### PR TITLE
update manifest for OpenStudio 3.4.0 packages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -60,33 +60,33 @@
     "type": "mongo"
   }],
   "openstudio": [{
-    "name": "OpenStudio-3.4.0-rc2-Windows.tar.gz",
+    "name": "OpenStudio-3.4.0-Windows.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.4.0-rc2-Darwin.tar.gz",
+    "name": "OpenStudio-3.4.0-Darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.4.0-rc2-Linux.tar.gz",
+    "name": "OpenStudio-3.4.0-Linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio"
   }],
   "openstudioServer": [{
-    "name": "OpenStudio-server-8f660515f1-win32.tar.gz",
+    "name": "OpenStudio-server-88db5b902e-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-8f660515f1-darwin.tar.gz",
+    "name": "OpenStudio-server-88db5b902e-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-8f660515f1-linux.tar.gz",
+    "name": "OpenStudio-server-88db5b902e-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio-server"


### PR DESCRIPTION
Updating manifest to include OpenStudio 3.4.0 and server gems. 