### PR TITLE
#231: Fix grid on Options page

### DIFF
--- a/app/app/index.scss
+++ b/app/app/index.scss
@@ -367,7 +367,9 @@ select {
 }
 
 .ui-grid-category {
-  text-align: center;border-right: 0px;box-shadow: -1px 1px #d4d4d4
+  text-align: center;
+  border-right: 0px;
+  box-shadow: -1px 0px #d4d4d4
 }
 
 /* this allows no trim of whitespace at front or end of strings in editable grid cells */

--- a/app/app/outputs/headerTemplate.html
+++ b/app/app/outputs/headerTemplate.html
@@ -1,29 +1,39 @@
-<div role="rowgroup"
-     class="ui-grid-header">
+<div role="rowgroup" class="ui-grid-header">
   <div class="ui-grid-top-panel">
     <div class="ui-grid-header-viewport">
       <div class="ui-grid-header-canvas">
-        <div class="ui-grid-header-cell-wrapper"
-             ng-style="colContainer.headerCellWrapperStyle()">
-          <div role="row"
-               class="ui-grid-header-cell-row">
-            <div class="ui-grid-header-cell ui-grid-clearfix ui-grid-category" ng-repeat="cat in grid.options.category"
-                 ng-if="cat.visible &&
-                             (colContainer.renderedColumns | filter:{ colDef:{category: cat.name} }).length > 0">
-              {{cat.name}}
-              <div class="ui-grid-header-cell ui-grid-clearfix"
-                   ng-repeat="col in colContainer.renderedColumns | filter:{ colDef:{category: cat.name} }"
-                   ui-grid-header-cell
-                   col="col"
-                   render-index="$index">
+        <div
+          class="ui-grid-header-cell-wrapper"
+          ng-style="colContainer.headerCellWrapperStyle()"
+        >
+          <div role="row" class="ui-grid-header-cell-row">
+            <div
+              ng-repeat="cat in grid.options.category"
+              ng-if="cat.visible &&
+                             (colContainer.renderedColumns | filter:{ colDef:{category: cat.name} }).length > 0"
+            >
+              <div class="ui-grid-category">{{cat.name}}</div>
+              <div role="row" class="ui-grid-header-cell-row">
+                <div
+                  role="columnheader"
+                  class="ui-grid-header-cell"
+                  ng-repeat="col in colContainer.renderedColumns | filter:{ colDef:{category: cat.name} }"
+                  ui-grid-header-cell
+                  col="col"
+                  render-index="$index"
+                ></div>
               </div>
-            </div><!--!cat.visible && -->
-            <div class="ui-grid-header-cell ui-grid-clearfix" ng-if="col.colDef.category === undefined"
-                 ng-repeat="col in colContainer.renderedColumns track by col.uid"
-                 ui-grid-header-cell
-                 col="col"
-                 render-index="$index">
             </div>
+            <!--!cat.visible && -->
+            <div
+              role="columnheader"
+              class="ui-grid-header-cell"
+              ng-if="col.colDef.category === undefined"
+              ng-repeat="col in colContainer.renderedColumns track by col.uid"
+              ui-grid-header-cell
+              col="col"
+              render-index="$index"
+            ></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR fixes the bug where the grid was not being displayed correctly on the Options page (see #231)

Before:
![broken-ui-grid](https://user-images.githubusercontent.com/6434784/194109473-f847429c-0fb9-4162-9dfa-3b86678df303.png)

After:
![fixed-ui-grid](https://user-images.githubusercontent.com/6434784/194111170-12780a74-03d9-420f-8ecb-5c51c1070c4b.png)
