### PR TITLE
#235: Use "npx gulp" instead of relying on executable script

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   },
   "scripts": {
     "postinstall": "cd app && npm install",
-    "build": "./node_modules/.bin/gulp build",
-    "release": "./node_modules/.bin/gulp release --env=production",
+    "build": "npx gulp build",
+    "release": "npx gulp release --env=production",
     "start": "node ./tasks/start",
     "start:dist": "node ./tasks/start --env=production",
     "test": "node ./tasks/start --env=test"


### PR DESCRIPTION
This PR fixes the build issue on Windows, documented in #235 