### PR TITLE
fix reports detecting when page is loaded

### DIFF
--- a/app/app/reports/reports.html
+++ b/app/app/reports/reports.html
@@ -16,5 +16,7 @@
 <webview id=wv
          autosize="on"
          style="height:calc(100vh - 150px)"
-         nodeintegration>
+         nodeintegration
+         webpreferences="contextIsolation=false"
+         >
 </webview>

--- a/app/app/reports/reportsController.js
+++ b/app/app/reports/reportsController.js
@@ -51,7 +51,6 @@ export class ReportsController {
     vm.$scope.datapoints = vm.Project.getDatapoints();
     if (vm.Message.showDebug()) vm.$log.debug('DATAPOINTS: ', vm.$scope.datapoints);
     vm.testResults = vm.$scope.datapoints;
-
     // get algorithmic results
     vm.selectedAnalysisType = vm.Project.getAnalysisType();
     vm.algorithmic_results = [];
@@ -119,17 +118,21 @@ export class ReportsController {
           wv.attr('src', vm.$scope.selectedReportURL);
         }
       });
-      //pass data into webview when dom is ready
-      angular.element(document).on('ready', vm.passData);
+      // pass data into webview when dom is ready
+      angular.element(document).ready(() => {
+        vm.passData();
+      })
     };
 
     // Uncomment this to view webview developer tools to debug project reports
     // if (vm.env != 'production') {
-    //  vm.openWebViewDevTools();
+    //   vm.openWebViewDevTools();
     // }
 
-    //pass data into webview when dom is ready
-    angular.element(document).on('ready', vm.passData);
+    // pass data into webview when dom is ready
+    angular.element(document).ready(() => {
+      vm.passData();
+    })
   }
 
   // Opens the developer tools for the webview


### PR DESCRIPTION
Fixes #254 
The reports were erroring out (silently) before the data could load. this fixes it.

To test: run an analysis and ensure that datapoints show up in the EDAPT report.