### PR TITLE
new labs MeasureManager

### DIFF
--- a/copyright.txt
+++ b/copyright.txt
@@ -1,5 +1,5 @@
 OpenStudio
-Copyright (c) 2008-2020, Alliance for Sustainable Energy
+Copyright (c) 2008-2023, Alliance for Sustainable Energy
 All Rights Reserved.
 
 

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2020, Alliance for Sustainable Energy.
+Copyright (c) 2008-2023, Alliance for Sustainable Energy.
 All rights reserved.
 
                                    NOTICE


### PR DESCRIPTION
PAT updates for new labs MeasureManager

now starting measure manager with the following command:

`openstudio labs measure -s <port number>`

Ready to merge when you want to use this new MeasureManager!
works with openstudio starting with [this version](https://github.com/NREL/OpenStudio/commit/13cbc82a689b326677ab42fa5577c68501b9e1c1).
