### PR TITLE
Add classic flag to openstudio calling.

### DIFF
--- a/app/app/main/measureManagerService.js
+++ b/app/app/main/measureManagerService.js
@@ -71,7 +71,7 @@ export class MeasureManager {
       vm.$log.info('Measure Manager port: ', vm.port);
 
       vm.$log.info('Start Measure Manager Server: ', vm.cliPath, ' measure -s ', vm.port);
-      vm.cli = vm.spawn(vm.cliPath, ['measure', '-s', vm.port]);
+      vm.cli = vm.spawn(vm.cliPath, ['classic', 'measure', '-s', vm.port]);
       vm.cli.stdout.on('data', (data) => {
         // record errors
         if (data.indexOf('<0>') !== -1) {


### PR DESCRIPTION
tested run locally with

```
npm start
```

and from the developer window I could see:

```
Measure Manager getMyMeasuresDir Success!, status:  200
```

Which indicate the communication from PAT to openstudio works well.