### PR TITLE
Update and release 390-rc1

### DIFF
--- a/.github/workflows/build_pat.yaml
+++ b/.github/workflows/build_pat.yaml
@@ -123,7 +123,7 @@ jobs:
         cmake --build . --target package -j 2
 
     - name: Save artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: ./build/ParametricAnalysisTool-*
 

--- a/.github/workflows/build_pat.yaml
+++ b/.github/workflows/build_pat.yaml
@@ -125,6 +125,7 @@ jobs:
     - name: Save artifact
       uses: actions/upload-artifact@v4
       with:
+        name: PAT-Installer-${{ matrix.name }}
         path: ./build/ParametricAnalysisTool-*
 
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14.0)
 cmake_policy(SET CMP0048 NEW)
 
 
-project(ParametricAnalysisTool VERSION 3.8.0)
+project(ParametricAnalysisTool VERSION 3.9.0)
 
 
 find_package(Git)

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pat",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pat",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "dependencies": {
         "@electron/remote": "~2.0.8",
         "adm-zip": "~0.5.9",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pat",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pat",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "dependencies": {
         "@electron/remote": "~2.0.8",
         "adm-zip": "~0.5.9",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "ParametricAnalysisTool",
   "identifier": "gov.nrel.openstudio.pat",
   "description": "OpenStudio Parametric Analysis Tool",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "author": "National Renewable Energy Laboratory",
   "main": "background.js",
   "dependencies": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,17 @@
 {
   "endpoint": "https://openstudio-resources.s3.amazonaws.com/pat-dependencies3/",
   "energyplus": [{
-    "name": "EnergyPlus-24.1.0-win32.tar.gz",
+    "name": "EnergyPlus-24.2.0-win32.tar",
     "platform": "win32",
     "arch": "x64",
     "type": "energyplus"
   }, {
-    "name": "EnergyPlus-24.1.0-darwin.tar.gz",
+    "name": "EnergyPlus-24.2.0-darwin.tar",
     "platform": "darwin",
     "arch": "x64",
     "type": "energyplus"
   }, {
-    "name": "EnergyPlus-24.1.0-linux.tar.gz",
+    "name": "EnergyPlus-24.2.0-linux.tar",
     "platform": "linux",
     "arch": "x64",
     "type": "energyplus"
@@ -60,17 +60,17 @@
     "type": "mongo"
   }],
   "openstudio": [{
-    "name": "OpenStudio-3.8.0-Windows.tar.gz",
+    "name": "OpenStudio-3.9.0-Windows.tar",
     "platform": "win32",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.8.0-Darwin.tar.gz",
+    "name": "OpenStudio-3.9.0-Darwin.tar",
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.8.0-Linux.tar.gz",
+    "name": "OpenStudio-3.9.0-Linux.tar",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio"

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,17 @@
 {
   "endpoint": "https://openstudio-resources.s3.amazonaws.com/pat-dependencies3/",
   "energyplus": [{
-    "name": "EnergyPlus-24.2.0-win32.tar",
+    "name": "EnergyPlus-24.2.0-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "energyplus"
   }, {
-    "name": "EnergyPlus-24.2.0-darwin.tar",
+    "name": "EnergyPlus-24.2.0-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "energyplus"
   }, {
-    "name": "EnergyPlus-24.2.0-linux.tar",
+    "name": "EnergyPlus-24.2.0-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "energyplus"
@@ -60,17 +60,17 @@
     "type": "mongo"
   }],
   "openstudio": [{
-    "name": "OpenStudio-3.9.0-Windows.tar",
+    "name": "OpenStudio-3.9.0-Windows.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.9.0-Darwin.tar",
+    "name": "OpenStudio-3.9.0-Darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.9.0-Linux.tar",
+    "name": "OpenStudio-3.9.0-Linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openstudio-pat",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "devDependencies": {
     "@babel/core": "~7.19.3",
     "@babel/eslint-parser": "~7.19.1",


### PR DESCRIPTION
- Update the Github Action follows by [Deprecation notice: v1 and v2 of the artifact actions](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
- OpenStudio has updated to 3.9.0, comes with [webrick](https://github.com/NREL/openstudio-gems/blob/v3.9.0-RC3/Gemfile#L127)
- With correct directory structure to remedy the #278 
- The minimal version of Linux should be Ubuntu 2204.