### PR TITLE
Update and release 3.10.0-rc1

### DIFF
--- a/.github/workflows/build_pat.yaml
+++ b/.github/workflows/build_pat.yaml
@@ -31,7 +31,7 @@ jobs:
           allow_failure: false
           MACOSX_DEPLOYMENT_TARGET: 10.15
           SDKROOT: /Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+          DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
         - name: Windows_2022
           os: windows-2022
           node-version: 18

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14.0)
 cmake_policy(SET CMP0048 NEW)
 
 
-project(ParametricAnalysisTool VERSION 3.9.1)
+project(ParametricAnalysisTool VERSION 3.10.0)
 
 
 find_package(Git)

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pat",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pat",
-      "version": "3.9.1",
+      "version": "3.10.0",
       "dependencies": {
         "@electron/remote": "~2.0.8",
         "adm-zip": "~0.5.9",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "ParametricAnalysisTool",
   "identifier": "gov.nrel.openstudio.pat",
   "description": "OpenStudio Parametric Analysis Tool",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "author": "National Renewable Energy Laboratory",
   "main": "background.js",
   "dependencies": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,17 @@
 {
   "endpoint": "https://openstudio-resources.s3.amazonaws.com/pat-dependencies3/",
   "energyplus": [{
-    "name": "EnergyPlus-24.2.0-win32.tar.gz",
+    "name": "EnergyPlus-25.1.0-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "energyplus"
   }, {
-    "name": "EnergyPlus-24.2.0-darwin.tar.gz",
+    "name": "EnergyPlus-25.1.0-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "energyplus"
   }, {
-    "name": "EnergyPlus-24.2.0-linux.tar.gz",
+    "name": "EnergyPlus-25.1.0-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "energyplus"
@@ -49,33 +49,33 @@
     "type": "mongo"
   }],
   "openstudio": [{
-    "name": "OpenStudio-3.9.0-Windows.tar.gz",
+    "name": "OpenStudio-3.10.0-Windows.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.9.0-Darwin.tar.gz",
+    "name": "OpenStudio-3.10.0-Darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "openstudio"
   }, {
-    "name": "OpenStudio-3.9.0-Linux.tar.gz",
+    "name": "OpenStudio-3.10.0-Linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio"
   }],
   "openstudioServer": [{
-    "name": "OpenStudio-server-415ae851b8-win32.tar.gz",
+    "name": "OpenStudio-server-5873e0d21d-win32.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-415ae851b8-darwin.tar.gz",
+    "name": "OpenStudio-server-5873e0d21d-darwin.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "OpenStudio-server"
   }, {
-    "name": "OpenStudio-server-415ae851b8-linux.tar.gz",
+    "name": "OpenStudio-server-5873e0d21d-linux.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "OpenStudio-server"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openstudio-pat",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openstudio-pat",
-      "version": "3.9.1",
+      "version": "3.10.0",
       "hasInstallScript": true,
       "devDependencies": {
         "@babel/core": "~7.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openstudio-pat",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "devDependencies": {
     "@babel/core": "~7.19.3",
     "@babel/eslint-parser": "~7.19.1",


### PR DESCRIPTION
Updates version numbers in CMakeLists.txt and package files while changing the macOS build workflow to use Xcode 13.2.1 instead of 11.7.