### PR TITLE
Update MongoDB file extensions in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,17 +33,17 @@
     "type": "ruby"
   }],
   "mongo": [{
-    "name": "mongodb-windows-x86_64-8.0.12.tgz",
+    "name": "mongodb-win32-x86_64-windows-8.0.12.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "mongo"
   },{
-    "name": "mongodb-macos-x86_64-8.0.12.tgz",
+    "name": "mongodb-macos-x86_64-8.0.12.tar.gz",
     "platform": "darwin",
     "arch": "x64",
     "type": "mongo"
   }, {
-    "name": "mongodb-linux-x86_64-ubuntu2404-8.0.12.tgz",
+    "name": "mongodb-linux-x86_64-ubuntu2404-8.0.12.tar.gz",
     "platform": "linux",
     "arch": "x64",
     "type": "mongo"

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
     "type": "ruby"
   }],
   "mongo": [{
-    "name": "mongodb-win32-x86_64-windows-8.0.12.tar.gz",
+    "name": "mongodb-windows-x86_64-8.0.12.tar.gz",
     "platform": "win32",
     "arch": "x64",
     "type": "mongo"


### PR DESCRIPTION
Change MongoDB file extensions from .tgz to .tar.gz for consistency in the manifest.